### PR TITLE
Fixed bug with wrong rope collision handling for BoxCollider2D

### DIFF
--- a/rope/Assets/Job.cs
+++ b/rope/Assets/Job.cs
@@ -197,7 +197,7 @@ namespace RopeJobs {
                             }
 
                             float dy = localPoint.y;
-                            float py = half.x - Mathf.Abs(dy);
+                            float py = half.y - Mathf.Abs(dy);
                             if (py <= 0) {
                                 continue;
                             }

--- a/rope/Assets/Rope.cs
+++ b/rope/Assets/Rope.cs
@@ -349,7 +349,7 @@ using UnityEngine.Profiling;
                              }
 
                              float dy = localPoint.y;
-                             float py = half.x - Mathf.Abs(dy);
+                             float py = half.y - Mathf.Abs(dy);
                              if (py <= 0) {
                                  continue;
                              }


### PR DESCRIPTION
Collision handling did not work correctly with non-square BoxCollider2D colliders (collider.size.x != collider.size.y)